### PR TITLE
Improve Neo4j Query Performance By Using MERGE

### DIFF
--- a/nodestream_plugin_neo4j/database_connector.py
+++ b/nodestream_plugin_neo4j/database_connector.py
@@ -22,6 +22,9 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
         cls,
         use_enterprise_features: bool = False,
         use_apoc: bool = True,
+        chunk_size: int = 1000,
+        execute_chunks_in_parallel: bool = True,
+        retries_per_chunk: int = 3,
         **connection_args
     ):
         database_connection = Neo4jDatabaseConnection.from_configuration(
@@ -31,6 +34,9 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
             database_connection=database_connection,
             use_enterprise_features=use_enterprise_features,
             use_apoc=use_apoc,
+            chunk_size=chunk_size,
+            execute_chunks_in_parallel=execute_chunks_in_parallel,
+            retries_per_chunk=retries_per_chunk,
         )
 
     def __init__(
@@ -38,14 +44,26 @@ class Neo4jDatabaseConnector(DatabaseConnector, alias="neo4j"):
         database_connection: Neo4jDatabaseConnection,
         use_apoc: bool,
         use_enterprise_features: bool,
+        chunk_size: int = 1000,
+        execute_chunks_in_parallel: bool = True,
+        retries_per_chunk: int = 3,
     ) -> None:
         self.use_enterprise_features = use_enterprise_features
         self.use_apoc = use_apoc
         self.database_connection = database_connection
+        self.chunk_size = chunk_size
+        self.execute_chunks_in_parallel = execute_chunks_in_parallel
+        self.retries_per_chunk = retries_per_chunk
 
     def make_query_executor(self) -> QueryExecutor:
         query_builder = Neo4jIngestQueryBuilder(self.use_apoc)
-        return Neo4jQueryExecutor(self.database_connection, query_builder)
+        return Neo4jQueryExecutor(
+            self.database_connection,
+            query_builder,
+            chunk_size=self.chunk_size,
+            execute_chunks_in_parallel=self.execute_chunks_in_parallel,
+            retries_per_chunk=self.retries_per_chunk,
+        )
 
     def make_type_retriever(self) -> TypeRetriever:
         return Neo4jTypeRetriever(self.database_connection)

--- a/tests/unit/test_ingest_query_builder.py
+++ b/tests/unit/test_ingest_query_builder.py
@@ -194,11 +194,7 @@ RELATIONSHIP_BETWEEN_TWO_NODES = RelationshipWithNodes(
 
 RELATIONSHIP_BETWEEN_TWO_NODES_EXPECTED_QUERY = QueryBatch(
     """MATCH (from_node: TestType) WHERE from_node.id = params.__from_node_id MATCH (to_node: ComplexType) WHERE to_node.id = params.__to_node_id
-    OPTIONAL MATCH  (from_node)-[rel: RELATED_TO]->(to_node)
-    FOREACH (x IN CASE WHEN rel IS NULL THEN [1] ELSE [] END |
-        CREATE (from_node)-[rel: RELATED_TO]->(to_node) SET rel += params.__rel_properties)
-    FOREACH (i in CASE WHEN rel IS NOT NULL THEN [1] ELSE [] END |
-        SET rel += params.__rel_properties)
+    MERGE (from_node)-[rel: RELATED_TO]->(to_node) SET rel += params.__rel_properties
     """,
     [
         {
@@ -217,12 +213,7 @@ RELATIONSHIP_BETWEEN_TWO_NODES_WITH_MULTI_KEY = RelationshipWithNodes(
 
 RELATIONSHIP_BETWEEN_TWO_NODES_EXPECTED_QUERY_WITH_MULTI_KEY = QueryBatch(
     """MATCH (from_node: TestType) WHERE from_node.id = params.__from_node_id MATCH (to_node: ComplexType) WHERE to_node.id_part1 = params.__to_node_id_part1 AND to_node.id_part2 = params.__to_node_id_part2
-    OPTIONAL MATCH  (from_node)-[rel: RELATED_TO]->(to_node)
-    FOREACH (x IN CASE WHEN rel IS NULL THEN [1] ELSE [] END |
-        CREATE (from_node)-[rel: RELATED_TO]->(to_node) SET rel += params.__rel_properties)
-    FOREACH (i in CASE WHEN rel IS NOT NULL THEN [1] ELSE [] END |
-        SET rel += params.__rel_properties)
-    """,
+    MERGE (from_node)-[rel: RELATED_TO]->(to_node) SET rel += params.__rel_properties""",
     [
         {
             "__from_node_id": "foo",

--- a/tests/unit/test_query_executor.py
+++ b/tests/unit/test_query_executor.py
@@ -29,6 +29,19 @@ def query_executor(mocker):
 
 
 @pytest.mark.asyncio
+async def test_execute_query_batch(query_executor, some_query_batch, mocker):
+    expected_query = some_query_batch.as_query(
+        query_executor.ingest_query_builder.apoc_iterate,
+        chunk_size=query_executor.chunk_size,
+        execute_chunks_in_parallel=query_executor.execute_chunks_in_parallel,
+        retries_per_chunk=query_executor.retries_per_chunk,
+    )
+
+    await query_executor.execute_query_batch(some_query_batch)
+    assert_that(query_executor, ran_query(expected_query))
+
+
+@pytest.mark.asyncio
 async def test_upsert_nodes_in_bulk_of_same_operation(query_executor, some_query_batch):
     query_executor.ingest_query_builder.generate_batch_update_node_operation_batch.return_value = (
         some_query_batch


### PR DESCRIPTION
Due to some internal analysis done by intuit, while this query does perform better is certain situations, in others it can cause memory consumption spikes in the 10s of GBs on the cluster and can cause stability and consistency issues. This PR approaches using the more obvious MERGE path and leaving it to the database to execute this more in a stable manor. This PR also adds several settings (currently undocumented) that allow for some tweaking of the underlying batch performance.

NOTE: Docs excluded from this PR pending the docs revamp.