### PR TITLE
Release 0.15.0a4

### DIFF
--- a/nodestream_plugin_neo4j/extractor.py
+++ b/nodestream_plugin_neo4j/extractor.py
@@ -1,11 +1,29 @@
 from logging import getLogger
-from typing import Any, Dict, Optional
+from typing import Any, AsyncGenerator, Dict, Iterator, Mapping, Optional
 
-from neo4j import RoutingControl
+from neo4j import Record, RoutingControl
 from nodestream.pipeline import Extractor
 
 from .neo4j_database import Neo4jDatabaseConnection
 from .query import Query
+
+
+class Neo4jRecordWrapper(Mapping[str, Any]):
+    def __init__(self, record: Record) -> None:
+        self.original = record  # Maintained Context Object
+        self.data = record.data()  # Dictionary accessible view of the record.
+
+    def __getitem__(self, key: str) -> Any:
+        return self.data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.data)
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __repr__(self) -> str:
+        return f"Neo4jRecordWrapper(data={self.data})"
 
 
 class Neo4jExtractor(Extractor):
@@ -18,12 +36,7 @@ class Neo4jExtractor(Extractor):
         **connection_args,
     ):
         connector = Neo4jDatabaseConnection.from_configuration(**connection_args)
-        return cls(
-            query,
-            connector,
-            parameters,
-            limit,
-        )
+        return cls(query, connector, parameters, limit)
 
     def __init__(
         self,
@@ -38,7 +51,7 @@ class Neo4jExtractor(Extractor):
         self.limit = limit
         self.logger = getLogger(self.__class__.__name__)
 
-    async def extract_records(self):
+    async def extract_records(self) -> AsyncGenerator[Neo4jRecordWrapper, None]:
         offset = 0
         should_continue = True
 
@@ -60,5 +73,5 @@ class Neo4jExtractor(Extractor):
             returned_records = list(query_results)
             should_continue = len(returned_records) > 0
             offset += self.limit
-            for item in returned_records:
-                yield item.data()
+            for record in returned_records:
+                yield Neo4jRecordWrapper(record)

--- a/nodestream_plugin_neo4j/migrator.py
+++ b/nodestream_plugin_neo4j/migrator.py
@@ -136,6 +136,7 @@ DROP_NODE_PROPERTY_FORMAT = (
     "IN TRANSACTIONS OF {batch} ROWS"
 )
 
+
 class CannotAcquireLockException(Exception):
     pass
 

--- a/nodestream_plugin_neo4j/migrator.py
+++ b/nodestream_plugin_neo4j/migrator.py
@@ -54,8 +54,16 @@ RELEASE_LOCK_QUERY = Query.from_statement(
 LIST_MIGRATIONS_QUERY = "MATCH (m:__NodestreamMigration__) RETURN m.name as name"
 MARK_MIGRATION_AS_EXECUTED_QUERY = "MERGE (:__NodestreamMigration__ {name: $name})"
 
-DROP_ALL_NODES_OF_TYPE_FORMAT = "MATCH (n:`{type}`) WITH n CALL {{ WITH n DETACH DELETE n }} IN TRANSACTIONS OF {batch} ROWS"
-DROP_ALL_RELATIONSHIPS_OF_TYPE_FORMAT = "MATCH ()-[r:`{type}`]->() WITH r CALL {{ WITH r DELETE r }} IN TRANSACTIONS OF {batch} ROWS"
+DROP_ALL_NODES_OF_TYPE_FORMAT = (
+    "MATCH (n:`{type}`) "
+    "CALL {{ WITH n DETACH DELETE n }} "
+    "IN TRANSACTIONS OF {batch} ROWS"
+)
+DROP_ALL_RELATIONSHIPS_OF_TYPE_FORMAT = (
+    "MATCH ()-[r:`{type}`]->() "
+    "CALL {{ WITH r DELETE r }} "
+    "IN TRANSACTIONS OF {batch} ROWS"
+)
 
 INDEMPOTENT_DROP_INDEX_FORMAT = "DROP INDEX {index_name} IF EXISTS"
 INDEMPOTENT_DROP_CONSTRAINT = "DROP CONSTRAINT {constraint_name} IF EXISTS"
@@ -71,7 +79,8 @@ SET_RELATIONSHIP_PROPERTY_FORMAT = (
     "MATCH ()-[r:`{relationship_type}`]->() "
     "WHERE r.`{property_name}` IS NULL "
     "WITH r, $value AS value "
-    "CALL {{ WITH r, value SET r.`{property_name}` = coalesce(r.`{property_name}`, value) }} "
+    "CALL {{ WITH r, value "
+    "SET r.`{property_name}` = coalesce(r.`{property_name}`, value) }} "
     "IN TRANSACTIONS OF {batch} ROWS"
 )
 
@@ -84,14 +93,16 @@ REL_FIELD_INDEX_QUERY_FORMAT = "CREATE INDEX {constraint_name} IF NOT EXISTS FOR
 
 RENAME_NODE_PROPERTY_FORMAT = (
     "MATCH (n:`{node_type}`) "
-    "WITH n "
-    "CALL {{ WITH n SET n.`{new_property_name}` = n.`{old_property_name}` REMOVE n.`{old_property_name}` }} "
+    "CALL {{ WITH n "
+    "SET n.`{new_property_name}` = n.`{old_property_name}` "
+    "REMOVE n.`{old_property_name}` }} "
     "IN TRANSACTIONS OF {batch} ROWS"
 )
 RENAME_RELATIONSHIP_PROPERTY_FORMAT = (
     "MATCH ()-[r:`{relationship_type}`]->() "
-    "WITH r "
-    "CALL {{ WITH r SET r.`{new_property_name}` = r.`{old_property_name}` REMOVE r.`{old_property_name}` }} "
+    "CALL {{ WITH r "
+    "SET r.`{new_property_name}` = r.`{old_property_name}` "
+    "REMOVE r.`{old_property_name}` }} "
     "IN TRANSACTIONS OF {batch} ROWS"
 )
 
@@ -100,26 +111,27 @@ GET_INDEXES_BY_TYPE_QUERY = "SHOW INDEXES YIELD properties, entityType, labelsOr
 
 RENAME_NODE_TYPE = (
     "MATCH (n:`{old_type}`) "
-    "WITH n "
-    "CALL {{ WITH n SET n:`{new_type}` REMOVE n:`{old_type}` }} "
+    "CALL {{ WITH n "
+    "SET n:`{new_type}` "
+    "REMOVE n:`{old_type}` }} "
     "IN TRANSACTIONS OF {batch} ROWS"
 )
 RENAME_REL_TYPE = (
     "MATCH (n)-[r:`{old_type}`]->(m) "
-    "WITH n, r, m "
-    "CALL {{ WITH n, r, m CREATE (n)-[r2:`{new_type}`]->(m) SET r2 += r WITH r DELETE r }} "
+    "CALL {{ WITH n, r, m "
+    "CREATE (n)-[r2:`{new_type}`]->(m) "
+    "SET r2 += r "
+    "DELETE r }} "
     "IN TRANSACTIONS OF {batch} ROWS"
 )
 
 DROP_REL_PROPERTY_FORMAT = (
     "MATCH ()-[r:`{relationship_type}`]->() "
-    "WITH r "
     "CALL {{ WITH r REMOVE r.`{property_name}` }} "
     "IN TRANSACTIONS OF {batch} ROWS"
 )
 DROP_NODE_PROPERTY_FORMAT = (
     "MATCH (n:`{node_type}`) "
-    "WITH n "
     "CALL {{ WITH n REMOVE n.`{property_name}` }} "
     "IN TRANSACTIONS OF {batch} ROWS"
 )

--- a/nodestream_plugin_neo4j/migrator.py
+++ b/nodestream_plugin_neo4j/migrator.py
@@ -136,9 +136,6 @@ DROP_NODE_PROPERTY_FORMAT = (
     "IN TRANSACTIONS OF {batch} ROWS"
 )
 
-DEFAULT_AS_STRING = "null"
-
-
 class CannotAcquireLockException(Exception):
     pass
 
@@ -392,7 +389,9 @@ class Neo4jMigrator(OperationTypeRoutingMixin, Migrator):
             batch=self.transaction_batch_size,
         )
         query = Query.from_statement(
-            statement, value=operation.default or DEFAULT_AS_STRING, is_implicit=True
+            statement,
+            value=operation.default,
+            is_implicit=True,
         )
         await self.database_connection.execute(query)
 
@@ -405,7 +404,9 @@ class Neo4jMigrator(OperationTypeRoutingMixin, Migrator):
             batch=self.transaction_batch_size,
         )
         query = Query.from_statement(
-            statement, value=operation.default or DEFAULT_AS_STRING, is_implicit=True
+            statement,
+            value=operation.default,
+            is_implicit=True,
         )
         await self.database_connection.execute(query)
 
@@ -431,8 +432,13 @@ class Neo4jMigrator(OperationTypeRoutingMixin, Migrator):
 
     async def execute_node_key_extended(self, operation: NodeKeyExtended) -> None:
         constraint_name = operation.proposed_index_name
+        # For key extension, the new key property cannot be NULL, otherwise the
+        # node key / uniqueness constraint would fail. If the migration author
+        # did not provide an explicit default, fall back to the literal string
+        # "null" as a sentinel value so that the key is always populated.
+        key_default = operation.default if operation.default is not None else "null"
         as_add = AddNodeProperty(
-            operation.node_type, operation.added_key_property, operation.default
+            operation.node_type, operation.added_key_property, key_default
         )
         keys = await self.get_properties_by_constraint_name(constraint_name)
         keys.add(operation.added_key_property)

--- a/nodestream_plugin_neo4j/neo4j_database.py
+++ b/nodestream_plugin_neo4j/neo4j_database.py
@@ -103,6 +103,15 @@ class Neo4jDatabaseConnection:
             return self.acquire_driver()
         return self._driver
 
+    async def close(self) -> None:
+        """Close the underlying Neo4j driver if it has been created."""
+        driver = self._driver
+        if driver is not None:
+            # Set to None first so any concurrent callers will see that the
+            # driver is already being closed and will no-op.
+            self._driver = None
+            await driver.close()
+
     def log_query_start(self, query: Query):
         if query.query_statement not in self.query_set:
             self.logger.info(
@@ -202,8 +211,9 @@ class Neo4jDatabaseConnection:
                     attempts,
                     exc_info=e,
                 )
-                # Block synchronously before retrying (do not yield to event loop).
+                # Back off before retrying and rotate the driver instance.
                 time.sleep(self.retry_factor * attempts)
+                await self.close()
                 self.acquire_driver()
                 if attempts >= self.max_retry_attempts:
                     raise e

--- a/nodestream_plugin_neo4j/query_executor.py
+++ b/nodestream_plugin_neo4j/query_executor.py
@@ -80,3 +80,7 @@ class Neo4jQueryExecutor(QueryExecutor):
     async def execute_hook(self, hook: IngestionHook):
         query_string, params = hook.as_cypher_query_and_parameters()
         await self.database_connection.execute(Query(query_string, params))
+
+    async def finish(self):
+        """Close the underlying database connection and its driver."""
+        await self.database_connection.close()

--- a/nodestream_plugin_neo4j/type_retriever.py
+++ b/nodestream_plugin_neo4j/type_retriever.py
@@ -1,4 +1,4 @@
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Tuple, cast
 
 from neo4j.graph import Node as Neo4jNode
 from neo4j.graph import Relationship as Neo4jRelationship
@@ -13,8 +13,8 @@ MATCH (n:{type})
 RETURN n SKIP $offset LIMIT $limit
 """
 
-FETCH_ALL_RELATIONSHIPS_BY_TYPE_QUERY_FORMAT = """
-MATCH (a)-[r:{type}]->(b)
+FETCH_ALL_RELATIONSHIPS_BY_TYPE_BETWEEN_QUERY_FORMAT = """
+MATCH (a:{from_node_type})-[r:{relationship_type}]->(b:{to_node_type})
 RETURN a, r, b SKIP $offset LIMIT $limit
 """
 
@@ -24,51 +24,64 @@ class Neo4jTypeRetriever(TypeRetriever):
         self.database_connection = database_connection
 
     def map_neo4j_node_to_nodestream_node(
-        self, node: Neo4jNode, type: str = None
+        self, node: Neo4jNode, node_type: str
     ) -> Node:
-        # NOTE: I don't think this will work in all cases.
-        # But I think this will require shaking out in the future.
-        type = type or next(iter(node.labels))
         return Node(
-            type=type,
+            type=node_type,
             properties=PropertySet(node),
-            additional_types=tuple(label for label in node.labels if label != type),
+            additional_types=cast(
+                Tuple[str], tuple(label for label in node.labels if label != node_type)
+            ),
         )
 
     def map_neo4j_relationship_to_nodestream_relationship(
-        self, relationship: Neo4jRelationship
+        self, relationship: Neo4jRelationship, relationship_type: str
     ) -> Relationship:
         return Relationship(
-            type=relationship.type,
+            type=relationship_type,
             properties=PropertySet(relationship),
         )
 
-    def get_node_type_extractor(self, type: str) -> Neo4jExtractor:
+    def get_node_type_extractor(self, node_type: str) -> Neo4jExtractor:
         return Neo4jExtractor(
-            FETCH_ALL_NODES_BY_TYPE_QUERY_FORMAT.format(type=type),
+            FETCH_ALL_NODES_BY_TYPE_QUERY_FORMAT.format(type=node_type),
             self.database_connection,
         )
 
-    def get_relationship_type_extractor(self, type: str) -> Neo4jExtractor:
+    def get_relationships_of_type_bettween_extractor(
+        self, from_node_type: str, to_node_type: str, relationship_type: str
+    ) -> Neo4jExtractor:
         return Neo4jExtractor(
-            FETCH_ALL_RELATIONSHIPS_BY_TYPE_QUERY_FORMAT.format(type=type),
+            FETCH_ALL_RELATIONSHIPS_BY_TYPE_BETWEEN_QUERY_FORMAT.format(
+                from_node_type=from_node_type,
+                relationship_type=relationship_type,
+                to_node_type=to_node_type,
+            ),
             self.database_connection,
         )
 
-    async def get_nodes_of_type(self, type: str) -> AsyncGenerator[Node, None]:
-        extractor = self.get_node_type_extractor(type)
-        async for row in extractor.extract_records():
-            yield self.map_neo4j_node_to_nodestream_node(row["n"], type=type)
+    async def get_nodes_of_type(self, node_type: str) -> AsyncGenerator[Node, None]:
+        extractor = self.get_node_type_extractor(node_type)
+        async for record in extractor.extract_records():
+            yield self.map_neo4j_node_to_nodestream_node(
+                record.original["n"], node_type=node_type
+            )
 
-    async def get_relationships_of_type(
-        self, type: str
+    async def get_relationships_of_type_between(
+        self, from_node_type: str, to_node_type: str, relationship_type: str
     ) -> AsyncGenerator[RelationshipWithNodes, None]:
-        extractor = self.get_relationship_type_extractor(type)
-        async for row in extractor.extract_records():
+        extractor = self.get_relationships_of_type_bettween_extractor(
+            from_node_type, to_node_type, relationship_type
+        )
+        async for record in extractor.extract_records():
             yield RelationshipWithNodes(
-                from_node=self.map_neo4j_node_to_nodestream_node(row["a"]),
-                to_node=self.map_neo4j_node_to_nodestream_node(row["b"]),
+                from_node=self.map_neo4j_node_to_nodestream_node(
+                    record.original["a"], node_type=from_node_type
+                ),
+                to_node=self.map_neo4j_node_to_nodestream_node(
+                    record.original["b"], node_type=to_node_type
+                ),
                 relationship=self.map_neo4j_relationship_to_nodestream_relationship(
-                    row["r"]
+                    record.original["r"], relationship_type=relationship_type
                 ),
             )

--- a/poetry.lock
+++ b/poetry.lock
@@ -858,37 +858,35 @@ pyarrow = ["pyarrow (>=1.0.0)"]
 
 [[package]]
 name = "nodestream"
-version = "0.15.0a0"
+version = "0.15.0a1"
 description = "A Fast, Declarative ETL for Graph Databases."
 optional = false
-python-versions = "^3.10"
+python-versions = "<4.0,>=3.10"
 groups = ["main"]
-files = []
-develop = true
+files = [
+    {file = "nodestream-0.15.0a1-py3-none-any.whl", hash = "sha256:18afb044251511254b30968c9f72967d4527bed1bf13e5f1513e6b11704f2762"},
+    {file = "nodestream-0.15.0a1.tar.gz", hash = "sha256:d694bd75825e61827128c8b2ca4901027348dfb561ddf2826f1202a923c5d290"},
+]
 
 [package.dependencies]
-boto3 = "^1.34.127"
-cleo = "^2.0"
-confluent-kafka = "^2.5"
-cookiecutter = "^2.0"
-httpx = "^0.27"
-Jinja2 = "^3"
-jmespath = "^1.0"
-pandas = "^2"
-psutil = "^6.0"
+boto3 = ">=1.34.127,<2.0.0"
+cleo = ">=2.0,<3.0"
+confluent-kafka = ">=2.5,<3.0"
+cookiecutter = ">=2.0,<3.0"
+httpx = ">=0.27,<0.28"
+Jinja2 = ">=3,<4"
+jmespath = ">=1.0,<2.0"
+pandas = ">=2,<3"
+psutil = ">=6.0,<7.0"
 pyarrow = ">=17.0.0,<19.0.0"
-python-json-logger = "^2.0"
-pyyaml = "^6.0"
-schema = "^0.7"
+python-json-logger = ">=2.0,<3.0"
+pyyaml = ">=6.0,<7.0"
+schema = ">=0.7,<0.8"
 uvloop = {version = ">=0.17.0,<=0.21.0", markers = "sys_platform == \"darwin\" or sys_platform == \"linux\""}
 
 [package.extras]
 prometheus = ["prometheus-client (>=0.21.1,<0.22.0)"]
 validation = ["genson (>=1.3.0,<2.0.0)", "jsonschema (>=4.23.0,<5.0.0)"]
-
-[package.source]
-type = "directory"
-url = "../nodestream"
 
 [[package]]
 name = "numpy"
@@ -1964,4 +1962,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "eb1c3d39a30af4c44ef233417b61a9ebf92ef11dac3ba6d1faece0e25e0d36a2"
+content-hash = "5315a7e6991f1bc26338a7b7f866483b57d59241f7b0a10d9f44aa60a6feacb8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -861,32 +861,34 @@ name = "nodestream"
 version = "0.15.0a0"
 description = "A Fast, Declarative ETL for Graph Databases."
 optional = false
-python-versions = "<4.0,>=3.10"
+python-versions = "^3.10"
 groups = ["main"]
-files = [
-    {file = "nodestream-0.15.0a0-py3-none-any.whl", hash = "sha256:751fa1e2b8b655200943b69b945f5c82a2e2dea259fe0e51b5b9be9f533c38a8"},
-    {file = "nodestream-0.15.0a0.tar.gz", hash = "sha256:b341d8ffa0a77ddd8b03eaaed0107bb6a157791d5346cbc4f7f33b1f1090ef6d"},
-]
+files = []
+develop = true
 
 [package.dependencies]
-boto3 = ">=1.34.127,<2.0.0"
-cleo = ">=2.0,<3.0"
-confluent-kafka = ">=2.5,<3.0"
-cookiecutter = ">=2.0,<3.0"
-httpx = ">=0.27,<0.28"
-Jinja2 = ">=3,<4"
-jmespath = ">=1.0,<2.0"
-pandas = ">=2,<3"
-psutil = ">=6.0,<7.0"
+boto3 = "^1.34.127"
+cleo = "^2.0"
+confluent-kafka = "^2.5"
+cookiecutter = "^2.0"
+httpx = "^0.27"
+Jinja2 = "^3"
+jmespath = "^1.0"
+pandas = "^2"
+psutil = "^6.0"
 pyarrow = ">=17.0.0,<19.0.0"
-python-json-logger = ">=2.0,<3.0"
-pyyaml = ">=6.0,<7.0"
-schema = ">=0.7,<0.8"
+python-json-logger = "^2.0"
+pyyaml = "^6.0"
+schema = "^0.7"
 uvloop = {version = ">=0.17.0,<=0.21.0", markers = "sys_platform == \"darwin\" or sys_platform == \"linux\""}
 
 [package.extras]
 prometheus = ["prometheus-client (>=0.21.1,<0.22.0)"]
 validation = ["genson (>=1.3.0,<2.0.0)", "jsonschema (>=4.23.0,<5.0.0)"]
+
+[package.source]
+type = "directory"
+url = "../nodestream"
 
 [[package]]
 name = "numpy"
@@ -1962,4 +1964,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "6a6304df5bd811981d4b90bcc70e5f0c4618b10ccbc4ed145f16ffa939efd281"
+content-hash = "eb1c3d39a30af4c44ef233417b61a9ebf92ef11dac3ba6d1faece0e25e0d36a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-nodestream = "^0.15.0a0"
+# nodestream = "^0.15.0a1"
+nodestream = {path = "../nodestream", develop = true }
 neo4j = "^5.16.0"
 cymple = "^0.11.0"
 dacite = "^1.9.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,13 @@
 [tool.poetry]
 name = "nodestream-plugin-neo4j"
-version = "0.15.0a3"
+version = "0.15.0a4"
 description = ""
 authors = ["Zach Probst <Zach_Probst@intuit.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-# nodestream = "^0.15.0a1"
-nodestream = {path = "../nodestream", develop = true }
+nodestream = "^0.15.0a1"
 neo4j = "^5.16.0"
 cymple = "^0.11.0"
 dacite = "^1.9.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream-plugin-neo4j"
-version = "0.15.0a4"
+version = "0.15.0a5"
 description = ""
 authors = ["Zach Probst <Zach_Probst@intuit.com>"]
 readme = "README.md"

--- a/tests/e2e/test_type_retriever.py
+++ b/tests/e2e/test_type_retriever.py
@@ -1,0 +1,222 @@
+import pytest
+
+from nodestream_plugin_neo4j.neo4j_database import Neo4jDatabaseConnection
+from nodestream_plugin_neo4j.type_retriever import Neo4jTypeRetriever
+
+from .conftest import TESTED_NEO4J_VERSIONS
+
+# Global test parameters to avoid magic numbers and centralize expectations
+PERSON_LABEL = "Person"
+COMPANY_LABEL = "Company"
+RELATIONSHIP_TYPE = "WORKS_AT"
+
+# Single-container dataset sizes and expected relationship counts
+SINGLE_CONTAINER_PERSON_COUNT = 30
+SINGLE_CONTAINER_COMPANY_COUNT = 10
+SINGLE_CONTAINER_REL_COUNT = (
+    SINGLE_CONTAINER_PERSON_COUNT // 2
+) * SINGLE_CONTAINER_COMPANY_COUNT
+
+# Two-container dataset sizes (A smaller, B larger) and expected relationship counts
+CONTAINER_A_PERSON_COUNT = 20
+CONTAINER_A_COMPANY_COUNT = 5
+CONTAINER_A_REL_COUNT = (CONTAINER_A_PERSON_COUNT // 2) * CONTAINER_A_COMPANY_COUNT
+
+CONTAINER_B_PERSON_COUNT = 40
+CONTAINER_B_COMPANY_COUNT = 8
+CONTAINER_B_REL_COUNT = (CONTAINER_B_PERSON_COUNT // 2) * CONTAINER_B_COMPANY_COUNT
+
+
+def seed_graph(
+    session, num_people: int, num_companies: int, rel_type: str = RELATIONSHIP_TYPE
+):
+    """Populate the database with Persons, Companies, and WORKS_AT relationships."""
+    session.run(
+        f"""
+        UNWIND range(1, $n) AS i
+        MERGE (n:{PERSON_LABEL} {{ id: i }})
+        SET n += {{
+          name: 'p'+toString(i),
+          age: i,
+          active: i % 2 = 0,
+          tags: ['t'+toString(i), 'common'],
+          scores: [i, i+1],
+          created_at: datetime()
+        }}
+        """,
+        parameters={"n": num_people},
+    )
+    # Add an extra label to some nodes to validate multi-label handling
+    session.run(
+        f"""
+        MATCH (n:{PERSON_LABEL})
+        WHERE n.id % 2 = 0
+        SET n:Employee
+        """,
+    )
+    # Add another additional label to a different subset
+    session.run(
+        f"""
+        MATCH (n:{PERSON_LABEL})
+        WHERE n.id % 3 = 0
+        SET n:Contractor
+        """,
+    )
+    session.run(
+        f"""
+        UNWIND range(1, $n) AS i
+        MERGE (c:{COMPANY_LABEL} {{ id: i }})
+        SET c += {{
+          name: 'c'+toString(i),
+          rating: toFloat(i),
+          categories: ['catA','catB']
+        }}
+        """,
+        parameters={"n": num_companies},
+    )
+    # Add additional labels to a subset of companies
+    session.run(
+        f"""
+        MATCH (c:{COMPANY_LABEL})
+        WHERE c.id % 2 = 1
+        SET c:Vendor
+        """,
+    )
+    session.run(
+        f"""
+        MATCH (p:{PERSON_LABEL}), (c:{COMPANY_LABEL})
+        WHERE p.id % 2 = 0 AND c.id <= $n
+        WITH p, c
+        MERGE (p)-[r:{rel_type} {{ since: 2020 }}]->(c)
+        SET r += {{ last_ingested_at: datetime() }}
+        """,
+        parameters={"n": num_companies},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("neo4j_version", TESTED_NEO4J_VERSIONS)
+async def test_type_retriever_single_container(neo4j_container, neo4j_version):
+    # Start a single Neo4j container and seed it with test data
+    with neo4j_container(
+        neo4j_version
+    ) as primary_container, primary_container.get_driver() as primary_driver, primary_driver.session() as primary_session:
+        seed_graph(
+            primary_session,
+            num_people=SINGLE_CONTAINER_PERSON_COUNT,
+            num_companies=SINGLE_CONTAINER_COMPANY_COUNT,
+            rel_type=RELATIONSHIP_TYPE,
+        )
+
+        # Create a database connection and initialize the type retriever
+        primary_connection = Neo4jDatabaseConnection.from_configuration(
+            uri=primary_container.get_connection_url(),
+            username="neo4j",
+            password="password",
+        )
+        type_retriever = Neo4jTypeRetriever(primary_connection)
+
+        # Verify node retrieval by type
+        person_nodes = [
+            node async for node in type_retriever.get_nodes_of_type(PERSON_LABEL)
+        ]
+        assert len(person_nodes) == SINGLE_CONTAINER_PERSON_COUNT
+        # Ensure complex shapes made it through normalization and mapping
+        assert any(
+            "tags" in n.properties and isinstance(n.properties["tags"], list)
+            for n in person_nodes
+        )
+        assert any(
+            "scores" in n.properties and isinstance(n.properties["scores"], list)
+            for n in person_nodes
+        )
+        assert any(
+            "active" in n.properties and isinstance(n.properties["active"], bool)
+            for n in person_nodes
+        )
+        # At least one multi-labeled node should have an additional type
+        assert any("Employee" in n.additional_types for n in person_nodes)
+
+        # Verify relationship retrieval between specific node types
+        works_at_between_person_company = [
+            rel
+            async for rel in type_retriever.get_relationships_of_type_between(
+                PERSON_LABEL, COMPANY_LABEL, RELATIONSHIP_TYPE
+            )
+        ]
+        assert len(works_at_between_person_company) == SINGLE_CONTAINER_REL_COUNT
+        # All relationships should include the seeded property
+        assert all(
+            "since" in r.relationship.properties
+            for r in works_at_between_person_company
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e
+@pytest.mark.parametrize("neo4j_version", TESTED_NEO4J_VERSIONS)
+async def test_type_retriever_two_containers_counts(neo4j_container, neo4j_version):
+    """
+    Spin up two independent graphs with different sizes and ensure that:
+      - The container with larger seeded data returns more (or equal) results for the same queries.
+    """
+    with neo4j_container(
+        neo4j_version
+    ) as container_a, container_a.get_driver() as driver_a, driver_a.session() as session_a, neo4j_container(
+        neo4j_version
+    ) as container_b, container_b.get_driver() as driver_b, driver_b.session() as session_b:
+        # Seed different volumes of data in each container
+        seed_graph(
+            session_a,
+            num_people=CONTAINER_A_PERSON_COUNT,
+            num_companies=CONTAINER_A_COMPANY_COUNT,
+            rel_type=RELATIONSHIP_TYPE,
+        )
+        seed_graph(
+            session_b,
+            num_people=CONTAINER_B_PERSON_COUNT,
+            num_companies=CONTAINER_B_COMPANY_COUNT,
+            rel_type=RELATIONSHIP_TYPE,
+        )
+
+        # Initialize connections and type retrievers for each container
+        connection_a = Neo4jDatabaseConnection.from_configuration(
+            uri=container_a.get_connection_url(), username="neo4j", password="password"
+        )
+        connection_b = Neo4jDatabaseConnection.from_configuration(
+            uri=container_b.get_connection_url(), username="neo4j", password="password"
+        )
+        type_retriever_a = Neo4jTypeRetriever(connection_a)
+        type_retriever_b = Neo4jTypeRetriever(connection_b)
+
+        # Compare counts of Person nodes
+        person_nodes_a = [
+            n async for n in type_retriever_a.get_nodes_of_type(PERSON_LABEL)
+        ]
+        person_nodes_b = [
+            n async for n in type_retriever_b.get_nodes_of_type(PERSON_LABEL)
+        ]
+        assert len(person_nodes_a) == CONTAINER_A_PERSON_COUNT
+        assert len(person_nodes_b) == CONTAINER_B_PERSON_COUNT
+        assert len(person_nodes_b) >= len(person_nodes_a)
+        # Spot-check complex shapes exist in both containers
+        assert any("tags" in n.properties for n in person_nodes_a)
+        assert any("tags" in n.properties for n in person_nodes_b)
+
+        # Compare counts of WORKS_AT relationships specifically between Person and Company
+        works_at_between_a = [
+            r
+            async for r in type_retriever_a.get_relationships_of_type_between(
+                PERSON_LABEL, COMPANY_LABEL, RELATIONSHIP_TYPE
+            )
+        ]
+        works_at_between_b = [
+            r
+            async for r in type_retriever_b.get_relationships_of_type_between(
+                PERSON_LABEL, COMPANY_LABEL, RELATIONSHIP_TYPE
+            )
+        ]
+        assert len(works_at_between_a) == CONTAINER_A_REL_COUNT
+        assert len(works_at_between_b) == CONTAINER_B_REL_COUNT
+        assert len(works_at_between_b) >= len(works_at_between_a)

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -1,7 +1,7 @@
 import pytest
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, equal_to, has_length, is_
 
-from nodestream_plugin_neo4j.extractor import Neo4jExtractor
+from nodestream_plugin_neo4j.extractor import Neo4jExtractor, Neo4jRecordWrapper
 from nodestream_plugin_neo4j.neo4j_database import Neo4jDatabaseConnection
 from nodestream_plugin_neo4j.query import Query
 
@@ -14,6 +14,12 @@ class FakeRecord:
 
     def data(self):
         return self._payload
+
+    def keys(self):
+        return list(self._payload.keys())
+
+    def __getitem__(self, key):
+        return self._payload[key]
 
 
 @pytest.mark.asyncio
@@ -32,10 +38,14 @@ async def test_extract_records(mocker):
         [FakeRecord({"name": "test3"})],
         [],
     ]
-    result = [item async for item in extractor.extract_records()]
-    assert_that(
-        result, equal_to([{"name": "test1"}, {"name": "test2"}, {"name": "test3"}])
-    )
+    rows = [row async for row in extractor.extract_records()]
+    assert_that(rows, has_length(3))
+    # Should be our wrapper mapping view
+    assert isinstance(rows[0], Neo4jRecordWrapper)
+    names = [row["name"] for row in rows]
+    assert_that(names, equal_to(["test1", "test2", "test3"]))
+    # original should expose the underlying record with the same values
+    assert_that(rows[0].original["name"], is_("test1"))
 
     expected_query = Query(query, {"test": "test", "limit": 2, "offset": 0})
 

--- a/tests/unit/test_migrator.py
+++ b/tests/unit/test_migrator.py
@@ -50,7 +50,9 @@ async def test_execute_relationship_key_part_renamed(migrator):
     )
     await migrator.execute_operation(operation)
     expected_query = Query.from_statement(
-        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() WITH r CALL {{ WITH r SET r.`new_key` = r.`old_key` REMOVE r.`old_key` }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() "
+        f"CALL {{ WITH r SET r.`new_key` = r.`old_key` REMOVE r.`old_key` }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         is_implicit=True,
     )
     assert_that(migrator, ran_query(expected_query))
@@ -65,7 +67,9 @@ async def test_execute_relationship_property_renamed(migrator):
     )
     await migrator.execute_operation(operation)
     expected_query = Query.from_statement(
-        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() WITH r CALL {{ WITH r SET r.`new_prop` = r.`old_prop` REMOVE r.`old_prop` }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() "
+        f"CALL {{ WITH r SET r.`new_prop` = r.`old_prop` REMOVE r.`old_prop` }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         is_implicit=True,
     )
     assert_that(migrator, ran_query(expected_query))
@@ -78,7 +82,12 @@ async def test_execute_relationship_key_extended(migrator):
     )
     await migrator.execute_operation(operation)
     query = Query.from_statement(
-        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() WHERE r.`key` IS NULL WITH r, $value AS value CALL {{ WITH r, value SET r.`key` = coalesce(r.`key`, value) }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() "
+        f"WHERE r.`key` IS NULL "
+        f"WITH r, $value AS value "
+        f"CALL {{ WITH r, value "
+        f"SET r.`key` = coalesce(r.`key`, value) }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         value="foo",
         is_implicit=True,
     )
@@ -92,7 +101,12 @@ async def test_execute_relationship_property_added(migrator):
     )
     await migrator.execute_operation(operation)
     expected_query = Query.from_statement(
-        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() WHERE r.`prop` IS NULL WITH r, $value AS value CALL {{ WITH r, value SET r.`prop` = coalesce(r.`prop`, value) }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() "
+        f"WHERE r.`prop` IS NULL "
+        f"WITH r, $value AS value "
+        f"CALL {{ WITH r, value "
+        f"SET r.`prop` = coalesce(r.`prop`, value) }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         value="foo",
         is_implicit=True,
     )
@@ -106,7 +120,9 @@ async def test_execute_relationship_property_dropped(migrator):
     )
     await migrator.execute_operation(operation)
     query = Query.from_statement(
-        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() WITH r CALL {{ WITH r REMOVE r.`prop` }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() "
+        f"CALL {{ WITH r REMOVE r.`prop` }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         is_implicit=True,
     )
     assert_that(migrator, ran_query(query))
@@ -117,7 +133,12 @@ async def test_execute_relationship_type_renamed(migrator):
     operation = RenameRelationshipType(old_type="OLD_TYPE", new_type="NEW_TYPE")
     await migrator.execute_operation(operation)
     expected_query = Query.from_statement(
-        f"MATCH (n)-[r:`OLD_TYPE`]->(m) WITH n, r, m CALL {{ WITH n, r, m CREATE (n)-[r2:`NEW_TYPE`]->(m) SET r2 += r WITH r DELETE r }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH (n)-[r:`OLD_TYPE`]->(m) "
+        f"CALL {{ WITH n, r, m "
+        f"CREATE (n)-[r2:`NEW_TYPE`]->(m) "
+        f"SET r2 += r "
+        f"DELETE r }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         is_implicit=True,
     )
     assert_that(migrator, ran_query(expected_query))
@@ -134,7 +155,9 @@ async def test_execute_relationship_type_dropped(migrator):
     operation = DropRelationshipType(name="RELATIONSHIP_TYPE")
     await migrator.execute_operation(operation)
     expected_query = Query.from_statement(
-        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() WITH r CALL {{ WITH r DELETE r }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH ()-[r:`RELATIONSHIP_TYPE`]->() "
+        f"CALL {{ WITH r DELETE r }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         is_implicit=True,
     )
     assert_that(migrator, ran_query(expected_query))
@@ -145,7 +168,9 @@ async def test_execute_node_type_dropped(migrator):
     operation = DropNodeType(name="NodeType")
     await migrator.execute_operation(operation)
     expected_query = Query.from_statement(
-        f"MATCH (n:`NodeType`) WITH n CALL {{ WITH n DETACH DELETE n }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH (n:`NodeType`) "
+        f"CALL {{ WITH n DETACH DELETE n }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         is_implicit=True,
     )
     assert_that(migrator, ran_query(expected_query))
@@ -200,7 +225,11 @@ async def test_rename_node_property(migrator):
     )
     await migrator.execute_operation(operation)
     query = Query.from_statement(
-        f"MATCH (n:`NodeType`) WITH n CALL {{ WITH n SET n.`new_prop` = n.`old_prop` REMOVE n.`old_prop` }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH (n:`NodeType`) "
+        f"CALL {{ WITH n "
+        f"SET n.`new_prop` = n.`old_prop` "
+        f"REMOVE n.`old_prop` }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         is_implicit=True,
     )
     assert_that(migrator, ran_query(query))
@@ -211,7 +240,11 @@ async def test_rename_node_type(migrator):
     operation = RenameNodeType(old_type="OLD_TYPE", new_type="NEW_TYPE")
     await migrator.execute_operation(operation)
     expected_query = Query.from_statement(
-        f"MATCH (n:`OLD_TYPE`) WITH n CALL {{ WITH n SET n:`NEW_TYPE` REMOVE n:`OLD_TYPE` }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH (n:`OLD_TYPE`) "
+        f"CALL {{ WITH n "
+        f"SET n:`NEW_TYPE` "
+        f"REMOVE n:`OLD_TYPE` }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         is_implicit=True,
     )
     assert_that(migrator, ran_query(expected_query))
@@ -261,7 +294,9 @@ async def test_drop_node_property(migrator):
     operation = DropNodeProperty(property_name="prop", node_type="NodeType")
     await migrator.execute_operation(operation)
     query = Query.from_statement(
-        f"MATCH (n:`NodeType`) WITH n CALL {{ WITH n REMOVE n.`prop` }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
+        f"MATCH (n:`NodeType`) "
+        f"CALL {{ WITH n REMOVE n.`prop` }} "
+        f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         is_implicit=True,
     )
     assert_that(migrator, ran_query(query))
@@ -291,6 +326,10 @@ async def test_node_key_renamed(migrator, mocker):
     assert_that(
         migrator,
         (
-            f"MATCH (n:`NodeType`) WITH n CALL {{ WITH n SET n.`key` = n.`foo` REMOVE n.`foo` }} IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS"
+            f"MATCH (n:`NodeType`) "
+            f"CALL {{ WITH n "
+            f"SET n.`key` = n.`foo` "
+            f"REMOVE n.`foo` }} "
+            f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS"
         ),
     )

--- a/tests/unit/test_type_retriver.py
+++ b/tests/unit/test_type_retriver.py
@@ -1,11 +1,52 @@
+from typing import cast as type_cast
+
 import pytest
 from hamcrest import assert_that, equal_to, has_length
+from neo4j import Record
 from neo4j.graph import Node as Neo4jNode
 from neo4j.graph import Relationship as Neo4jRelationship
-from nodestream.model import Node, Relationship
+from nodestream.model import Node, PropertySet, Relationship
 
+from nodestream_plugin_neo4j.extractor import Neo4jRecordWrapper
 from nodestream_plugin_neo4j.neo4j_database import Neo4jDatabaseConnection
 from nodestream_plugin_neo4j.type_retriever import Neo4jTypeRetriever
+
+
+class FakeNeo4jNode(dict):
+    """Dict-like object with a .labels attribute, mimicking neo4j.graph.Node."""
+
+    def __init__(self, labels, props):
+        super().__init__(props)
+        self.labels = frozenset(labels)
+
+
+class FakeNeo4jRel(dict):
+    """Dict-like object mimicking neo4j.graph.Relationship."""
+
+    def __init__(self, rel_type, props):
+        super().__init__(props)
+        self.type = rel_type
+
+
+class FakeRecord:
+    """Mimics a neo4j Record for testing (supports .data() and __getitem__).
+
+    .data() returns plain dicts (like the real driver), but __getitem__
+    returns the original objects (FakeNeo4jNode / FakeNeo4jRel) so that
+    record.original[key] preserves graph-object attributes like .labels.
+    """
+
+    def __init__(self, payload):
+        self._p = payload
+
+    def data(self):
+        return {k: dict(v) if isinstance(v, dict) else v for k, v in self._p.items()}
+
+    def keys(self):
+        return list(self._p.keys())
+
+    def __getitem__(self, k):
+        return self._p[k]
 
 
 @pytest.fixture
@@ -15,32 +56,23 @@ def subject(mocker):
 
 
 def test_map_neo4j_node_to_nodestream_node(subject):
-    neo4j_node = Neo4jNode(None, None, None, ("Person", "Employee"), {"name": "John"})
-    result = subject.map_neo4j_node_to_nodestream_node(neo4j_node, type="Person")
+    neo_node = FakeNeo4jNode(("Person", "Employee"), {"name": "John", "id": 123})
+    result = subject.map_neo4j_node_to_nodestream_node(
+        type_cast(Neo4jNode, neo_node), node_type="Person"
+    )
     assert result == Node(
         type="Person",
-        properties={"name": "John"},
+        properties=PropertySet({"name": "John", "id": 123}),
         additional_types=("Employee",),
     )
 
 
 def test_map_neo4j_relationship_to_nodestream_relationship(subject):
-    # For reasons passing understanding, the Neo4jRelationship class is not
-    # actually the type that you get back. If you look at the constructor for
-    # it you will see that it takes not `type`, yet `type` is a property of
-    # the class. How could this be? Well, it turns out that the class is subclassed
-    # dynamically by the driver. So, we have to create a mock class that has the
-    # same properties as the real class.
-
-    class KNOWS(Neo4jRelationship):
-        pass
-
-    neo4j_rel = KNOWS(None, None, "KNOWS", {"since": 2019})
-    result = subject.map_neo4j_relationship_to_nodestream_relationship(neo4j_rel)
-    assert result == Relationship(
-        type="KNOWS",
-        properties={"since": 2019},
+    rel = FakeNeo4jRel("KNOWS", {"since": 2019})
+    result = subject.map_neo4j_relationship_to_nodestream_relationship(
+        type_cast(Neo4jRelationship, rel), relationship_type="KNOWS"
     )
+    assert result == Relationship(type="KNOWS", properties=PropertySet({"since": 2019}))
 
 
 def test_get_node_type_extractor(subject):
@@ -52,10 +84,12 @@ RETURN n SKIP $offset LIMIT $limit
     assert_that(extractor.query, equal_to(expected_query))
 
 
-def test_get_relationship_type_extractor(subject):
-    extractor = subject.get_relationship_type_extractor("KNOWS")
+def test_get_relationships_of_type_bettween_extractor(subject):
+    extractor = subject.get_relationships_of_type_bettween_extractor(
+        "Person", "Company", "KNOWS"
+    )
     expected_query = """
-MATCH (a)-[r:KNOWS]->(b)
+MATCH (a:Person)-[r:KNOWS]->(b:Company)
 RETURN a, r, b SKIP $offset LIMIT $limit
 """
     assert_that(extractor.query, equal_to(expected_query))
@@ -74,22 +108,48 @@ async def test_get_nodes_of_type(subject, mocker):
     subject.map_neo4j_node_to_nodestream_node = mocker.Mock()
     subject.get_node_type_extractor = mocker.Mock()
     extractor = subject.get_node_type_extractor.return_value
-    extractor.extract_records.return_value = async_generator({"n": 1}, {"n": 2})
+    n1 = FakeNeo4jNode(("Person",), {"id": 1, "name": "p1"})
+    n2 = FakeNeo4jNode(("Person", "Employee"), {"id": 2, "name": "p2"})
+    extractor.extract_records.return_value = async_generator(
+        Neo4jRecordWrapper(type_cast(Record, FakeRecord({"n": n1}))),
+        Neo4jRecordWrapper(type_cast(Record, FakeRecord({"n": n2}))),
+    )
     results = [r async for r in subject.get_nodes_of_type("Person")]
     assert_that(results, has_length(2))
+    # Verify the mapping function received the original node objects
+    subject.map_neo4j_node_to_nodestream_node.assert_any_call(n1, node_type="Person")
+    subject.map_neo4j_node_to_nodestream_node.assert_any_call(n2, node_type="Person")
 
 
 @pytest.mark.asyncio
-async def test_get_relationships_of_type(subject, mocker):
+async def test_get_relationships_of_type_between(subject, mocker):
     # Stub out the extractor to return specific values and
     # stub the conversion processes. This is a unit test to
     # test the loop itself not the entire process.
     subject.map_neo4j_node_to_nodestream_node = mocker.Mock()
     subject.map_neo4j_relationship_to_nodestream_relationship = mocker.Mock()
-    subject.get_relationship_type_extractor = mocker.Mock()
-    extractor = subject.get_relationship_type_extractor.return_value
+    subject.get_relationships_of_type_bettween_extractor = mocker.Mock()
+    extractor = subject.get_relationships_of_type_bettween_extractor.return_value
+    a1 = FakeNeo4jNode(("Person",), {"id": 1})
+    b1 = FakeNeo4jNode(("Company",), {"id": 10})
+    r1 = FakeNeo4jRel("KNOWS", {"since": 2019})
+    a2 = FakeNeo4jNode(("Person",), {"id": 2})
+    b2 = FakeNeo4jNode(("Company",), {"id": 11})
+    r2 = FakeNeo4jRel("KNOWS", {"since": 2020})
     extractor.extract_records.return_value = async_generator(
-        {"a": 1, "b": 2, "r": 3}, {"a": 3, "b": 4, "r": 5}
+        Neo4jRecordWrapper(type_cast(Record, FakeRecord({"a": a1, "b": b1, "r": r1}))),
+        Neo4jRecordWrapper(type_cast(Record, FakeRecord({"a": a2, "b": b2, "r": r2}))),
     )
-    results = [r async for r in subject.get_relationships_of_type("KNOWS")]
+    results = [
+        r
+        async for r in subject.get_relationships_of_type_between(
+            "Person", "Company", "KNOWS"
+        )
+    ]
     assert_that(results, has_length(2))
+    # Verify the mapping functions received the original objects
+    subject.map_neo4j_node_to_nodestream_node.assert_any_call(a1, node_type="Person")
+    subject.map_neo4j_node_to_nodestream_node.assert_any_call(b1, node_type="Company")
+    subject.map_neo4j_relationship_to_nodestream_relationship.assert_any_call(
+        r1, relationship_type="KNOWS"
+    )


### PR DESCRIPTION
 - Updating the type retriever to fetch nodes and relationships by adjacencies.
- Fixed the neo4j extractor to provide an object that wraps around the original neo4j record object and acts as a dictionary
- Actually closing the drivers when we acquire a new one.
- Fixing up some of the migration queries.