### PR TITLE
Add driver rotation lock to prevent concurrent auth hammering 

### DIFF
--- a/nodestream_plugin_neo4j/neo4j_database.py
+++ b/nodestream_plugin_neo4j/neo4j_database.py
@@ -149,12 +149,14 @@ class Neo4jDatabaseConnection:
         log_result: bool = False,
         routing_=RoutingControl.WRITE,
     ) -> Iterable[Record]:
+        driver = await self._get_driver()
         if query.is_implicit:
-            return await self.execute_implicit_query(query, log_result, routing_)
-        return await self.execute_explicit_query(query, log_result, routing_)
+            return await self._run_implicit_query(driver, query, log_result, routing_)
+        return await self._run_explicit_query(driver, query, log_result, routing_)
 
-    async def execute_implicit_query(
+    async def _run_implicit_query(
         self,
+        driver: AsyncDriver,
         query: Query,
         log_result: bool = False,
         routing_=RoutingControl.WRITE,
@@ -164,7 +166,6 @@ class Neo4jDatabaseConnection:
         # the routing hint onto the appropriate access mode here.
         access_mode = convert_routing_control_to_access_mode(routing_)
 
-        driver = await self._get_driver()
         async with driver.session(
             database=self.database_name,
             default_access_mode=access_mode,
@@ -180,14 +181,14 @@ class Neo4jDatabaseConnection:
             result = Neo4jResult(query, records, keys_list, summary)
         return self._finalize_query_result(query, result, log_result)
 
-    async def execute_explicit_query(
+    async def _run_explicit_query(
         self,
+        driver: AsyncDriver,
         query: Query,
         log_result: bool = False,
         routing_=RoutingControl.WRITE,
     ) -> Iterable[Record]:
         # TODO we need to use Neo4j's Query classes to avoid string interpolation in the future for injection protection.
-        driver = await self._get_driver()
         native: EagerResult = await driver.execute_query(
             query.query_statement,
             query.parameters,

--- a/nodestream_plugin_neo4j/neo4j_database.py
+++ b/nodestream_plugin_neo4j/neo4j_database.py
@@ -1,5 +1,4 @@
-import time
-from dataclasses import dataclass as _unused_dataclass  # noqa: F401
+import asyncio
 from logging import getLogger
 from typing import Awaitable, Callable, Iterable, Tuple, Union
 
@@ -18,6 +17,7 @@ from neo4j import (
 from neo4j.auth_management import AsyncAuthManagers
 from neo4j.exceptions import (
     AuthError,
+    ClientError,
     ServiceUnavailable,
     SessionExpired,
     TransientError,
@@ -28,6 +28,16 @@ from .query import Query
 from .result import Neo4jQueryStatistics, Neo4jResult
 
 RETRYABLE_EXCEPTIONS = (TransientError, ServiceUnavailable, SessionExpired, AuthError)
+AUTH_RATE_LIMIT_CODE = "Neo.ClientError.Security.AuthenticationRateLimit"
+
+
+def is_retryable(e: Exception) -> bool:
+    if isinstance(e, RETRYABLE_EXCEPTIONS):
+        return True
+    # AuthenticationRateLimit is a ClientError (not AuthError) but is transient.
+    return (
+        isinstance(e, ClientError) and getattr(e, "code", None) == AUTH_RATE_LIMIT_CODE
+    )
 
 
 def convert_routing_control_to_access_mode(routing_control: RoutingControl) -> str:
@@ -92,33 +102,43 @@ class Neo4jDatabaseConnection:
         self.retry_factor = retry_factor
         self._driver: AsyncDriver | None = None
         self.query_set: set[str] = set()
+        self._driver_lock = asyncio.Lock()
 
-    def acquire_driver(self) -> AsyncDriver:
-        self._driver = self.driver_factory()
-        return self._driver
+    async def _get_driver(self) -> AsyncDriver:
+        """Return the current driver, waiting if a rotation is in progress."""
+        async with self._driver_lock:
+            if self._driver is None:
+                self._driver = self.driver_factory()
+            return self._driver
 
-    @property
-    def driver(self) -> AsyncDriver:
-        if self._driver is None:
-            return self.acquire_driver()
-        return self._driver
+    async def _rotate_driver(self, attempts: int) -> None:
+        """Close the current driver, back off, then create a fresh one.
+
+        Holds _driver_lock for the entire duration so concurrent _get_driver()
+        callers block until the fresh driver is ready.
+        """
+        async with self._driver_lock:
+            if self._driver is not None:
+                await self._driver.close()
+                self._driver = None
+            await asyncio.sleep(self.retry_factor * attempts)
+            self._driver = self.driver_factory()
 
     async def close(self) -> None:
         """Close the underlying Neo4j driver if it has been created."""
-        driver = self._driver
+        async with self._driver_lock:
+            driver, self._driver = self._driver, None
         if driver is not None:
-            # Set to None first so any concurrent callers will see that the
-            # driver is already being closed and will no-op.
-            self._driver = None
             await driver.close()
 
-    def log_query_start(self, query: Query):
+    async def log_query_start(self, query: Query):
         if query.query_statement not in self.query_set:
+            driver = await self._get_driver()
             self.logger.info(
                 "Executing Cypher Query to Neo4j.",
                 extra={
                     "query": query.query_statement,
-                    "uri": self.driver._pool.address.host,
+                    "uri": driver._pool.address.host,
                 },
             )
             self.query_set.add(query.query_statement)
@@ -144,7 +164,8 @@ class Neo4jDatabaseConnection:
         # the routing hint onto the appropriate access mode here.
         access_mode = convert_routing_control_to_access_mode(routing_)
 
-        async with self.driver.session(
+        driver = await self._get_driver()
+        async with driver.session(
             database=self.database_name,
             default_access_mode=access_mode,
         ) as session:
@@ -166,7 +187,8 @@ class Neo4jDatabaseConnection:
         routing_=RoutingControl.WRITE,
     ) -> Iterable[Record]:
         # TODO we need to use Neo4j's Query classes to avoid string interpolation in the future for injection protection.
-        native: EagerResult = await self.driver.execute_query(
+        driver = await self._get_driver()
+        native: EagerResult = await driver.execute_query(
             query.query_statement,
             query.parameters,
             database_=self.database_name,
@@ -199,24 +221,24 @@ class Neo4jDatabaseConnection:
         log_result: bool = False,
         routing_=RoutingControl.WRITE,
     ) -> Iterable[Record]:
-        self.log_query_start(query)
+        await self.log_query_start(query)
         attempts = 0
         while True:
             attempts += 1
             try:
                 return await self._execute_query(query, log_result, routing_)
-            except RETRYABLE_EXCEPTIONS as e:
+            except Exception as e:
+                if not is_retryable(e):
+                    raise
                 self.logger.warning(
-                    "Error executing query, retrying. Attempt %s",
+                    "Error executing query, rotating driver and backing off. Attempt %s",
                     attempts,
                     exc_info=e,
                 )
-                # Back off before retrying and rotate the driver instance.
-                time.sleep(self.retry_factor * attempts)
-                await self.close()
-                self.acquire_driver()
                 if attempts >= self.max_retry_attempts:
-                    raise e
+                    raise
+                await self._rotate_driver(attempts)
 
-    def session(self) -> AsyncSession:
-        return self.driver.session(database=self.database_name)
+    async def session(self) -> AsyncSession:
+        driver = await self._get_driver()
+        return driver.session(database=self.database_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ isort = "^5.13.2"
 h11 = "0.16.0"
 
 [tool.pytest.ini_options]
+testpaths = ["tests/unit", "tests/integration"]
 markers = [
     "integration: marks the test as an integration test (deselect with '-m \"not integration\"')",
     "e2e: marks the test as an end-to-end test (deselect with '-m \"not e2e\"')",

--- a/tests/integration/test_driver_lock_contention.py
+++ b/tests/integration/test_driver_lock_contention.py
@@ -1,0 +1,180 @@
+"""
+Integration tests for Neo4jDatabaseConnection driver rotation behaviour.
+
+These tests are outcome-driven: given a driver that raises a retryable error,
+we assert that the bad driver is only called once (rotation replaces it) and
+that concurrent callers do not re-use the bad driver while rotation is in
+progress.
+
+No lock internals are inspected — only observable call counts on the drivers.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from neo4j import AsyncDriver
+from neo4j.exceptions import ClientError, ServiceUnavailable
+
+from nodestream_plugin_neo4j.neo4j_database import (
+    AUTH_RATE_LIMIT_CODE,
+    Neo4jDatabaseConnection,
+)
+from nodestream_plugin_neo4j.query import Query
+
+A_QUERY = Query("MATCH (n) RETURN n", {})
+ANOTHER_QUERY = Query("MATCH (r) RETURN r", {})
+
+
+def _make_driver_result(mocker) -> Mock:
+    result = mocker.Mock()
+    result.records = []
+    result.keys = []
+    summary = mocker.Mock()
+    summary.result_available_after = 0
+    summary.result_consumed_after = 0
+    counters = mocker.Mock()
+    for attr in [
+        "nodes_created",
+        "nodes_deleted",
+        "relationships_created",
+        "relationships_deleted",
+        "properties_set",
+        "labels_added",
+        "labels_removed",
+        "constraints_added",
+        "constraints_removed",
+        "indexes_added",
+        "indexes_removed",
+    ]:
+        setattr(counters, attr, 0)
+    summary.counters = counters
+    result.summary = summary
+    return result
+
+
+def make_bad_driver(mocker, error: Exception) -> AsyncMock:
+    driver = mocker.AsyncMock(AsyncDriver)
+    driver.execute_query.side_effect = error
+    return driver
+
+
+def make_good_driver(mocker) -> AsyncMock:
+    driver = mocker.AsyncMock(AsyncDriver)
+    driver.execute_query.return_value = _make_driver_result(mocker)
+    return driver
+
+
+def make_db(driver_sequence, retry_factor=0) -> Neo4jDatabaseConnection:
+    drivers = iter(driver_sequence)
+    return Neo4jDatabaseConnection(
+        driver_factory=lambda: next(drivers),
+        database_name="neo4j",
+        max_retry_attempts=3,
+        retry_factor=retry_factor,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — bad driver is only called once; rotation produces a working driver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_bad_driver_called_once_then_rotated(mocker):
+    """
+    When the first driver raises a retryable Neo4j error, execute() rotates
+    to a fresh driver and retries.  The bad driver must be called exactly
+    once — rotation must not cause it to be re-used.
+    """
+    bad_driver = make_bad_driver(mocker, ServiceUnavailable("neo4j is down"))
+    good_driver = make_good_driver(mocker)
+
+    db = make_db([bad_driver, good_driver])
+    await db.execute(A_QUERY)
+
+    assert bad_driver.execute_query.call_count == 1, (
+        f"Bad driver should have been called exactly once before rotation, "
+        f"got {bad_driver.execute_query.call_count}"
+    )
+    assert good_driver.execute_query.call_count == 1, (
+        f"Good driver should have been called exactly once after rotation, "
+        f"got {good_driver.execute_query.call_count}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_auth_rate_limit_error_treated_as_retryable(mocker):
+    """
+    Neo.ClientError.Security.AuthenticationRateLimit is a ClientError that is
+    specifically whitelisted as retryable. The bad driver is rotated and the
+    good driver is used for the retry — same outcome as TransientError etc.
+    Other ClientErrors (syntax errors, constraint violations) are not retried.
+    """
+    rate_limit_error = ClientError("too many attempts")
+    rate_limit_error._neo4j_code = AUTH_RATE_LIMIT_CODE
+
+    bad_driver = make_bad_driver(mocker, rate_limit_error)
+    good_driver = make_good_driver(mocker)
+
+    db = make_db([bad_driver, good_driver])
+    await db.execute(A_QUERY)
+
+    assert bad_driver.execute_query.call_count == 1
+    assert good_driver.execute_query.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — concurrent callers do not re-use the bad driver during rotation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_concurrent_callers_do_not_reuse_bad_driver(mocker):
+    """
+    When caller A hits an error and rotates the driver, any concurrent caller B
+    that arrives while rotation is in progress must wait and then use the fresh
+    driver — it must NOT call execute_query on the bad driver.
+    """
+    a_rotating = asyncio.Event()
+    a_may_finish = asyncio.Event()
+
+    bad_driver = make_bad_driver(mocker, ServiceUnavailable("down"))
+    good_driver = make_good_driver(mocker)
+
+    db = make_db([bad_driver, good_driver], retry_factor=1)
+
+    real_sleep = asyncio.sleep
+
+    async def controlled_sleep(delay):
+        # A is now inside _rotate_driver() — signal B to try and then wait.
+        a_rotating.set()
+        await a_may_finish.wait()
+
+    mocker.patch("asyncio.sleep", controlled_sleep)
+
+    a_task = asyncio.ensure_future(db.execute(A_QUERY))
+    await a_rotating.wait()
+
+    # B arrives while A is rotating — it must not call the bad driver.
+    b_task = asyncio.ensure_future(db.execute(ANOTHER_QUERY))
+    await real_sleep(0)
+    await real_sleep(0)
+
+    assert bad_driver.execute_query.call_count == 1, (
+        f"Bad driver should have been called exactly once (by A before it errored), "
+        f"got {bad_driver.execute_query.call_count}"
+    )
+
+    a_may_finish.set()
+    await a_task
+    await b_task
+
+    # Both A's retry and B should have used the good driver.
+    assert good_driver.execute_query.call_count == 2, (
+        f"Good driver should have been called twice (A retry + B), "
+        f"got {good_driver.execute_query.call_count}"
+    )

--- a/tests/unit/test_neo4j_database.py
+++ b/tests/unit/test_neo4j_database.py
@@ -18,16 +18,21 @@ SOME_RECORDS = [
 
 
 @pytest.fixture
-def database_connection(mocker):
-    return Neo4jDatabaseConnection(
-        lambda: mocker.AsyncMock(AsyncDriver), "neo4j", 2, 0.1
-    )
+def mock_driver(mocker):
+    return mocker.AsyncMock(AsyncDriver)
+
+
+@pytest.fixture
+def database_connection(mock_driver):
+    db = Neo4jDatabaseConnection(lambda: mock_driver, "neo4j", 2, 0.1)
+    db._driver = mock_driver
+    return db
 
 
 @pytest.mark.asyncio
-async def test_execute(database_connection, mocker):
+async def test_execute(database_connection, mock_driver, mocker):
     # Mock driver result with required attributes
-    driver_result = database_connection.driver.execute_query.return_value
+    driver_result = mock_driver.execute_query.return_value
     driver_result.records = SOME_RECORDS
     driver_result.keys = ["n"]
     # Summary with timings and empty counters
@@ -50,7 +55,7 @@ async def test_execute(database_connection, mocker):
     driver_result.summary = summary
     result = await database_connection.execute(A_QUERY, log_result=True)
     assert_that(result, equal_to(SOME_RECORDS))
-    database_connection.driver.execute_query.assert_called_once_with(
+    mock_driver.execute_query.assert_called_once_with(
         A_QUERY.query_statement,
         A_QUERY.parameters,
         database_="neo4j",
@@ -60,10 +65,7 @@ async def test_execute(database_connection, mocker):
 
 @pytest.mark.asyncio
 async def test_execute_fail_and_then_succeed(database_connection, mocker):
-    database_connection.acquire_driver = mocker.Mock(
-        wraps=database_connection.acquire_driver
-    )
-    # First call fails, second call returns a proper driver result
+    # First driver raises a transient error; second driver succeeds.
     driver_result = mocker.Mock()
     driver_result.records = SOME_RECORDS
     driver_result.keys = ["n"]
@@ -83,13 +85,23 @@ async def test_execute_fail_and_then_succeed(database_connection, mocker):
     counters.indexes_added = 0
     counters.indexes_removed = 0
     summary.counters = counters
-    driver_result.summary = summary
-    database_connection.driver.execute_query.side_effect = [
-        TransientError("Failed to execute query"),
-        driver_result,
-    ]
+
+    failing_driver = mocker.AsyncMock(AsyncDriver)
+    failing_driver.execute_query.side_effect = TransientError("Failed to execute query")
+    succeeding_driver = mocker.AsyncMock(AsyncDriver)
+    succeeding_driver.execute_query.return_value = driver_result
+
+    call_count = 0
+
+    def driver_factory():
+        nonlocal call_count
+        call_count += 1
+        return failing_driver if call_count == 1 else succeeding_driver
+
+    database_connection._driver = None
+    database_connection.driver_factory = driver_factory
     await database_connection.execute(A_QUERY)
-    assert_that(database_connection.acquire_driver.call_count, equal_to(2))
+    assert_that(call_count, equal_to(2))
 
 
 @pytest.mark.asyncio
@@ -99,16 +111,17 @@ async def test_execute_fail_and_then_fail(database_connection, mocker):
         driver.execute_query.side_effect = TransientError("Failed to execute query")
         return driver
 
+    database_connection._driver = None
     database_connection.driver_factory = driver_factory
     with pytest.raises(TransientError):
         await database_connection.execute(A_QUERY)
 
 
 @pytest.mark.asyncio
-async def test_session(database_connection):
-    session = database_connection.session()
-    assert_that(session, equal_to(database_connection.driver.session.return_value))
-    database_connection.driver.session.assert_called_once_with(database="neo4j")
+async def test_session(database_connection, mock_driver):
+    session = await database_connection.session()
+    assert_that(session, equal_to(mock_driver.session.return_value))
+    mock_driver.session.assert_called_once_with(database="neo4j")
 
 
 @pytest.mark.asyncio
@@ -132,7 +145,9 @@ async def test_auth_provider_factory_with_static_values():
 
 
 @pytest.mark.asyncio
-async def test_execute_implicit_uses_session_run(database_connection, mocker):
+async def test_execute_implicit_uses_session_run(
+    database_connection, mock_driver, mocker
+):
     # Build a query that should run implicitly
     implicit_query = Query.from_statement(
         "MATCH (n) RETURN n LIMIT $limit", is_implicit=True, limit=2
@@ -167,15 +182,15 @@ async def test_execute_implicit_uses_session_run(database_connection, mocker):
     session_cm.__aenter__.return_value = session_cm
     session_cm.__aexit__.return_value = False
     session_cm.run = mocker.AsyncMock(return_value=async_result)
-    database_connection.driver.session.return_value = session_cm
+    mock_driver.session.return_value = session_cm
 
     # Execute
     result = await database_connection.execute(implicit_query, log_result=True)
 
     # Assert records collected and driver.execute_query not used
     assert_that(result, equal_to(SOME_RECORDS))
-    database_connection.driver.execute_query.assert_not_called()
-    database_connection.driver.session.assert_called_once()
+    mock_driver.execute_query.assert_not_called()
+    mock_driver.session.assert_called_once()
     session_cm.run.assert_called_once_with(
         implicit_query.query_statement, parameters=implicit_query.parameters
     )

--- a/tests/unit/test_neo4j_database.py
+++ b/tests/unit/test_neo4j_database.py
@@ -145,7 +145,7 @@ async def test_auth_provider_factory_with_static_values():
 
 
 @pytest.mark.asyncio
-async def test_execute_implicit_uses_session_run(
+async def test_execute_implicit_uses_session_run(  # covers _run_implicit_query via execute()
     database_connection, mock_driver, mocker
 ):
     # Build a query that should run implicitly

--- a/tests/unit/test_query_executor.py
+++ b/tests/unit/test_query_executor.py
@@ -48,9 +48,7 @@ async def test_execute_query_batch(query_executor, some_query_batch, mocker):
 
 @pytest.mark.asyncio
 async def test_upsert_nodes_in_bulk_of_same_operation(query_executor, some_query_batch):
-    query_executor.ingest_query_builder.generate_batch_update_node_operation_batch.return_value = (
-        some_query_batch
-    )
+    query_executor.ingest_query_builder.generate_batch_update_node_operation_batch.return_value = some_query_batch
     await query_executor.upsert_nodes_in_bulk_with_same_operation(None, None)
     query_executor.ingest_query_builder.generate_batch_update_node_operation_batch.assert_called_once_with(
         None, None
@@ -64,9 +62,7 @@ async def test_upsert_nodes_in_bulk_of_same_operation(query_executor, some_query
 
 @pytest.mark.asyncio
 async def test_upsert_rel_in_bulk_of_same_shape(query_executor, some_query_batch):
-    query_executor.ingest_query_builder.generate_batch_update_relationship_query_batch.return_value = (
-        some_query_batch
-    )
+    query_executor.ingest_query_builder.generate_batch_update_relationship_query_batch.return_value = some_query_batch
     await query_executor.upsert_relationships_in_bulk_of_same_operation(None, None)
     query_executor.ingest_query_builder.generate_batch_update_relationship_query_batch.assert_called_once_with(
         None, None

--- a/tests/unit/test_query_executor.py
+++ b/tests/unit/test_query_executor.py
@@ -48,7 +48,9 @@ async def test_execute_query_batch(query_executor, some_query_batch, mocker):
 
 @pytest.mark.asyncio
 async def test_upsert_nodes_in_bulk_of_same_operation(query_executor, some_query_batch):
-    query_executor.ingest_query_builder.generate_batch_update_node_operation_batch.return_value = some_query_batch
+    query_executor.ingest_query_builder.generate_batch_update_node_operation_batch.return_value = (
+        some_query_batch
+    )
     await query_executor.upsert_nodes_in_bulk_with_same_operation(None, None)
     query_executor.ingest_query_builder.generate_batch_update_node_operation_batch.assert_called_once_with(
         None, None
@@ -62,7 +64,9 @@ async def test_upsert_nodes_in_bulk_of_same_operation(query_executor, some_query
 
 @pytest.mark.asyncio
 async def test_upsert_rel_in_bulk_of_same_shape(query_executor, some_query_batch):
-    query_executor.ingest_query_builder.generate_batch_update_relationship_query_batch.return_value = some_query_batch
+    query_executor.ingest_query_builder.generate_batch_update_relationship_query_batch.return_value = (
+        some_query_batch
+    )
     await query_executor.upsert_relationships_in_bulk_of_same_operation(None, None)
     query_executor.ingest_query_builder.generate_batch_update_relationship_query_batch.assert_called_once_with(
         None, None


### PR DESCRIPTION
  - Added asyncio.Lock (_driver_lock) on Neo4jDatabaseConnection                                                                                                           
  - Added _get_driver() — acquires the lock before returning the driver. If rotation is in progress, callers block here until the fresh driver is ready                  
  - Added _rotate_driver(attempts) — holds the lock for the entire close → backoff sleep → recreate cycle, so no concurrent caller can pick up the broken driver or fire   
  additional requests during the backoff window                                                                                                                            
  - Added AUTH_RATE_LIMIT_CODE constant and is_retryable(e) function — whitelists Neo.ClientError.Security.AuthenticationRateLimit as retryable without making all         
  ClientError subtypes (syntax errors, constraint violations, etc.) retryable                                                                                              
  - Fixed close() to atomically swap self._driver under the lock before closing                                                                                          
  - Removed acquire_driver() and the driver property — both bypassed _driver_lock making them unsafe for concurrent use   