### PR TITLE
fix: use properties() in RenameRelationshipType to avoid deprecated Cypher

### DIFF
--- a/nodestream_plugin_neo4j/migrator.py
+++ b/nodestream_plugin_neo4j/migrator.py
@@ -120,7 +120,7 @@ RENAME_REL_TYPE = (
     "MATCH (n)-[r:`{old_type}`]->(m) "
     "CALL {{ WITH n, r, m "
     "CREATE (n)-[r2:`{new_type}`]->(m) "
-    "SET r2 += r "
+    "SET r2 += properties(r) "
     "DELETE r }} "
     "IN TRANSACTIONS OF {batch} ROWS"
 )
@@ -156,6 +156,8 @@ class Neo4jMigrator(OperationTypeRoutingMixin, Migrator):
     async def make_node_constraint(
         self, node_type: str, keys: Iterable[str], constraint_name: str
     ) -> None:
+        if not keys:
+            return
         key_pattern = ",".join(f"n.`{p}`" for p in sorted(keys))
         format = (
             ENTERPRISE_KEY_INDEX_QUERY_FORMAT

--- a/poetry.lock
+++ b/poetry.lock
@@ -147,14 +147,14 @@ crt = ["awscrt (==0.23.8)"]
 
 [[package]]
 name = "certifi"
-version = "2025.1.31"
+version = "2026.2.25"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
-    {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
+    {file = "certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"},
+    {file = "certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"},
 ]
 
 [[package]]
@@ -646,14 +646,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.11"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
-    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+    {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
+    {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream-plugin-neo4j"
-version = "0.15.1"
+version = "0.15.2"
 description = ""
 authors = ["Zach Probst <Zach_Probst@intuit.com>"]
 readme = "README.md"

--- a/tests/e2e/test_neo4j_migrations.py
+++ b/tests/e2e/test_neo4j_migrations.py
@@ -344,23 +344,26 @@ class CreateRelationshipTypeScenario(Scenario):
 class RenameRelationshipTypeScenario(Scenario):
     def prepare_schema(self, session):
         session.run(
-            "CREATE INDEX RELATIONSHIP_weight_additional_index FOR ()-[r:RELATIONSHIP]-() ON (r.weight)"
+            "CREATE (:TestNode{id: 1})-[:RELATIONSHIP{weight: 0.5, label: 'edge'}]->(:TestNode{id: 2})"
         )
 
     def get_operation(self):
         return RenameRelationshipType("RELATIONSHIP", "NEW_RELATIONSHIP")
 
     def validate_operation(self, session):
-        result = session.run(
-            """
-            SHOW INDEXES
-            YIELD labelsOrTypes, properties
-            WHERE labelsOrTypes = ["NEW_RELATIONSHIP"]
-            RETURN properties
-            """
+        # Old type should be gone
+        old_result = session.run(
+            "MATCH ()-[r:RELATIONSHIP]->() RETURN count(r) as count"
         )
+        assert old_result.single()["count"] == 0
 
-        assert result.single()["properties"] == ["weight"]
+        # New type should exist with all original properties copied
+        new_result = session.run(
+            "MATCH ()-[r:NEW_RELATIONSHIP]->() RETURN r.weight as weight, r.label as label"
+        )
+        record = new_result.single()
+        assert record["weight"] == 0.5
+        assert record["label"] == "edge"
 
 
 class DropRelationshipTypeScenario(Scenario):

--- a/tests/unit/test_migrator.py
+++ b/tests/unit/test_migrator.py
@@ -136,7 +136,7 @@ async def test_execute_relationship_type_renamed(migrator):
         f"MATCH (n)-[r:`OLD_TYPE`]->(m) "
         f"CALL {{ WITH n, r, m "
         f"CREATE (n)-[r2:`NEW_TYPE`]->(m) "
-        f"SET r2 += r "
+        f"SET r2 += properties(r) "
         f"DELETE r }} "
         f"IN TRANSACTIONS OF {migrator.transaction_batch_size} ROWS",
         is_implicit=True,


### PR DESCRIPTION
…ypher

SET r2 += r where r is a relationship is deprecated in Neo4j 5.16 and will be removed in a future version. Replace with SET r2 += properties(r) which is the correct and forward-compatible form.

Also fix the unit test which was asserting the deprecated form, and improve the e2e scenario to actually create a relationship with properties and verify they are preserved after the rename.